### PR TITLE
feat: Add thread-safe hash table implementation with tests

### DIFF
--- a/workbench/.vscode/settings.json
+++ b/workbench/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["ctci", "hashtable"]
+}

--- a/workbench/go/pkg/hash/hash_table.go
+++ b/workbench/go/pkg/hash/hash_table.go
@@ -1,1 +1,0 @@
-package hash

--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -37,7 +37,7 @@ type HashChainTable[T comparable] struct {
 	// Table is an array of linked lists, where each bucket can contain multiple values
 	Table []*l.LinkedList[T]
 	// MaxSize is the maximum number of buckets in the hash table
-	MaxSize int64
+MaxSize int
 	// size tracks the total number of elements currently stored in the hash table
 	size int
 	// mu provides thread-safe access to the hash table

--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -37,7 +37,7 @@ type HashChainTable[T comparable] struct {
 	// Table is an array of linked lists, where each bucket can contain multiple values
 	Table []*l.LinkedList[T]
 	// MaxSize is the maximum number of buckets in the hash table
-MaxSize int
+	MaxSize int
 	// size tracks the total number of elements currently stored in the hash table
 	size int
 	// mu provides thread-safe access to the hash table
@@ -47,7 +47,7 @@ MaxSize int
 // NewHashChainTable creates and returns a new hash table with the specified maximum size.
 // The maxSize parameter determines the number of buckets in the hash table.
 // All buckets are initially empty (nil).
-func NewHashChainTable[T comparable](maxSize int64) *HashChainTable[T] {
+func NewHashChainTable[T comparable](maxSize int) *HashChainTable[T] {
 	if maxSize <= 0 {
 		panic("hashtable: maxSize must be positive")
 	}
@@ -56,7 +56,6 @@ func NewHashChainTable[T comparable](maxSize int64) *HashChainTable[T] {
 		MaxSize: maxSize,
 		size:    0,
 	}
-}
 }
 
 // Size returns the total number of elements currently stored in the hash table.

--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -48,11 +48,15 @@ type HashChainTable[T comparable] struct {
 // The maxSize parameter determines the number of buckets in the hash table.
 // All buckets are initially empty (nil).
 func NewHashChainTable[T comparable](maxSize int64) *HashChainTable[T] {
+	if maxSize <= 0 {
+		panic("hashtable: maxSize must be positive")
+	}
 	return &HashChainTable[T]{
 		Table:   make([]*l.LinkedList[T], maxSize),
 		MaxSize: maxSize,
 		size:    0,
 	}
+}
 }
 
 // Size returns the total number of elements currently stored in the hash table.

--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -128,7 +128,7 @@ func (table *HashChainTable[T]) Delete(value T) error {
 		return nil
 	}
 
-	if err := table.Table[index].Delete(value); err != nil {
+	if err = table.Table[index].Delete(value); err != nil {
 		return err
 	}
 

--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -1,5 +1,5 @@
 // Package hash_table provides a thread-safe hash table implementation using chaining for collision resolution.
-package hash_table
+package hashtable
 
 import (
 	"encoding/binary"

--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -1,0 +1,173 @@
+// Package hash_table provides a thread-safe hash table implementation using chaining for collision resolution.
+package hash_table
+
+import (
+	"encoding/binary"
+	"errors"
+	"hash"
+	"hash/fnv"
+	"math"
+	"sync"
+
+	l "github.com/haru-256/ctci-6th-edition/pkg/linked_list"
+)
+
+var (
+	// ErrorAlreadyExists is returned when attempting to insert a value that already exists in the hash table.
+	ErrorAlreadyExists = errors.New("value already exists in the hash table")
+	// ErrorUnsupportedValueType is returned when attempting to hash a value of an unsupported type.
+	ErrorUnsupportedValueType = errors.New("unsupported value type for hashing")
+)
+
+// hasherPool is a pool of FNV-1a hashers to avoid allocations in getHash.
+// This provides thread-safe access to reusable hash.Hash64 instances,
+// improving performance by reducing garbage collection pressure.
+var hasherPool = sync.Pool{
+	New: func() any {
+		return fnv.New64a()
+	},
+}
+
+// HashChainTable implements a thread-safe hash table using chaining for collision resolution.
+// It uses linked lists to handle hash collisions and supports generic types.
+// The hash table is safe for concurrent access with read-write mutex protection.
+type HashChainTable[T comparable] struct {
+	// Table is an array of linked lists, where each bucket can contain multiple values
+	Table []*l.LinkedList[T]
+	// MaxSize is the maximum number of buckets in the hash table
+	MaxSize int64
+	// size tracks the total number of elements currently stored in the hash table
+	size int
+	// mu provides thread-safe access to the hash table
+	mu sync.RWMutex
+}
+
+// NewHashChainTable creates and returns a new hash table with the specified maximum size.
+// The maxSize parameter determines the number of buckets in the hash table.
+// All buckets are initially empty (nil).
+func NewHashChainTable[T comparable](maxSize int64) *HashChainTable[T] {
+	return &HashChainTable[T]{
+		Table:   make([]*l.LinkedList[T], maxSize),
+		MaxSize: maxSize,
+		size:    0,
+	}
+}
+
+// Size returns the total number of elements currently stored in the hash table.
+// This method is thread-safe and uses a read lock for concurrent access.
+func (table *HashChainTable[T]) Size() int {
+	table.mu.RLock()
+	defer table.mu.RUnlock()
+	return table.size
+}
+
+// Insert adds a new value to the hash table.
+// If the value already exists, it returns ErrorAlreadyExists.
+// If the value type is not supported for hashing, it returns ErrorUnsupportedValueType.
+// This method is thread-safe and uses a write lock for concurrent access.
+func (table *HashChainTable[T]) Insert(value T) error {
+	table.mu.Lock()
+	defer table.mu.Unlock()
+
+	hash, err := table.getHash(value)
+	if err != nil {
+		return err
+	}
+
+	index := hash % uint64(table.MaxSize)
+	if table.Table[index] == nil {
+		table.Table[index] = l.NewLinkedList[T]()
+	}
+	if table.Table[index].Search(value) != nil {
+		return ErrorAlreadyExists
+	}
+
+	table.Table[index].Prepend(value)
+	table.size++
+	return nil
+}
+
+// Search looks for a value in the hash table and returns the corresponding node.
+// If the value is found, it returns the node containing the value.
+// If the value is not found, it returns nil for the node.
+// If the value type is not supported for hashing, it returns ErrorUnsupportedValueType.
+// This method is thread-safe and uses a read lock for concurrent access.
+func (table *HashChainTable[T]) Search(value T) (*l.Node[T], error) {
+	table.mu.RLock()
+	defer table.mu.RUnlock()
+
+	hash, err := table.getHash(value)
+	if err != nil {
+		return nil, err
+	}
+
+	index := hash % uint64(table.MaxSize)
+	if table.Table[index] == nil {
+		return nil, nil
+	}
+
+	return table.Table[index].Search(value), nil
+}
+
+// Delete removes a value from the hash table.
+// If the value exists, it is removed and the size is decremented.
+// If the value does not exist, the operation succeeds without error.
+// If the value type is not supported for hashing, it returns ErrorUnsupportedValueType.
+// This method is thread-safe and uses a write lock for concurrent access.
+func (table *HashChainTable[T]) Delete(value T) error {
+	table.mu.Lock()
+	defer table.mu.Unlock()
+
+	hash, err := table.getHash(value)
+	if err != nil {
+		return err
+	}
+
+	index := hash % uint64(table.MaxSize)
+	if table.Table[index] == nil {
+		return nil
+	}
+
+	if err := table.Table[index].Delete(value); err != nil {
+		return err
+	}
+
+	table.size--
+	return nil
+}
+
+// getHash computes and returns the FNV-1a hash of a given value.
+// It uses a sync.Pool to reuse hasher objects, making it safe for concurrent use
+// and avoiding allocations on each call.
+// It supports int, float64, and string types. For other types,
+// it returns ErrorUnsupportedValueType.
+func (table *HashChainTable[T]) getHash(value T) (uint64, error) {
+	// Get a hasher from the pool and defer returning it
+	hasher := hasherPool.Get().(hash.Hash64)
+	defer hasherPool.Put(hasher)
+	hasher.Reset()
+
+	// Convert the value to a byte slice based on its type.
+	var b []byte
+	switch v := any(value).(type) {
+	case int:
+		var buf [binary.MaxVarintLen64]byte
+		n := binary.PutVarint(buf[:], int64(v))
+		b = buf[:n]
+	case float64:
+		var buf [8]byte
+		binary.BigEndian.PutUint64(buf[:], math.Float64bits(v))
+		b = buf[:]
+	case string:
+		b = []byte(v)
+	default:
+		return 0, ErrorUnsupportedValueType
+	}
+
+	// Write the byte slice to the hasher.
+	// This Write is guaranteed not to return an error.
+	hasher.Write(b)
+
+	// Return the computed 64-bit hash.
+	return hasher.Sum64(), nil
+}

--- a/workbench/go/pkg/hash_table/hash_table_test.go
+++ b/workbench/go/pkg/hash_table/hash_table_test.go
@@ -1,0 +1,501 @@
+package hash_table
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHashChainTable(t *testing.T) {
+	tests := []struct {
+		name    string
+		maxSize int64
+	}{
+		{"small table", 5},
+		{"medium table", 100},
+		{"large table", 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewHashChainTable[string](tt.maxSize)
+
+			assert.NotNil(t, table)
+			assert.Equal(t, tt.maxSize, table.MaxSize)
+			assert.Equal(t, 0, table.Size())
+			assert.Equal(t, int(tt.maxSize), len(table.Table))
+
+			// Verify all buckets are initially nil
+			for i := int64(0); i < tt.maxSize; i++ {
+				assert.Nil(t, table.Table[i])
+			}
+		})
+	}
+}
+
+func TestHashChainTable_Size(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxSize      int64
+		insertValues []string
+		expectedSize int
+	}{
+		{
+			name:         "empty table",
+			maxSize:      10,
+			insertValues: []string{},
+			expectedSize: 0,
+		},
+		{
+			name:         "single element",
+			maxSize:      10,
+			insertValues: []string{"apple"},
+			expectedSize: 1,
+		},
+		{
+			name:         "multiple elements",
+			maxSize:      10,
+			insertValues: []string{"apple", "banana", "cherry"},
+			expectedSize: 3,
+		},
+		{
+			name:         "many elements",
+			maxSize:      5,
+			insertValues: []string{"a", "b", "c", "d", "e", "f", "g", "h"},
+			expectedSize: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewHashChainTable[string](tt.maxSize)
+
+			for _, value := range tt.insertValues {
+				err := table.Insert(value)
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.expectedSize, table.Size())
+		})
+	}
+}
+
+func TestHashChainTable_Insert(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxSize        int64
+		insertValues   []interface{}
+		expectedErrors []error
+		finalSize      int
+	}{
+		{
+			name:           "insert strings",
+			maxSize:        10,
+			insertValues:   []interface{}{"apple", "banana", "cherry"},
+			expectedErrors: []error{nil, nil, nil},
+			finalSize:      3,
+		},
+		{
+			name:           "insert integers",
+			maxSize:        5,
+			insertValues:   []interface{}{1, 2, 3, 4, 5},
+			expectedErrors: []error{nil, nil, nil, nil, nil},
+			finalSize:      5,
+		},
+		{
+			name:           "insert floats",
+			maxSize:        3,
+			insertValues:   []interface{}{1.1, 2.2, 3.3},
+			expectedErrors: []error{nil, nil, nil},
+			finalSize:      3,
+		},
+		{
+			name:           "insert duplicate",
+			maxSize:        5,
+			insertValues:   []interface{}{"apple", "banana", "apple"},
+			expectedErrors: []error{nil, nil, ErrorAlreadyExists},
+			finalSize:      2,
+		},
+		{
+			name:           "unsupported type",
+			maxSize:        5,
+			insertValues:   []interface{}{true}, // bool is not supported
+			expectedErrors: []error{ErrorUnsupportedValueType},
+			finalSize:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.insertValues[0].(type) {
+			case string:
+				table := NewHashChainTable[string](tt.maxSize)
+				for i, value := range tt.insertValues {
+					err := table.Insert(value.(string))
+					if tt.expectedErrors[i] != nil {
+						assert.ErrorIs(t, err, tt.expectedErrors[i])
+					} else {
+						assert.NoError(t, err)
+					}
+				}
+				assert.Equal(t, tt.finalSize, table.Size())
+			case int:
+				table := NewHashChainTable[int](tt.maxSize)
+				for i, value := range tt.insertValues {
+					err := table.Insert(value.(int))
+					if tt.expectedErrors[i] != nil {
+						assert.ErrorIs(t, err, tt.expectedErrors[i])
+					} else {
+						assert.NoError(t, err)
+					}
+				}
+				assert.Equal(t, tt.finalSize, table.Size())
+			case float64:
+				table := NewHashChainTable[float64](tt.maxSize)
+				for i, value := range tt.insertValues {
+					err := table.Insert(value.(float64))
+					if tt.expectedErrors[i] != nil {
+						assert.ErrorIs(t, err, tt.expectedErrors[i])
+					} else {
+						assert.NoError(t, err)
+					}
+				}
+				assert.Equal(t, tt.finalSize, table.Size())
+			case bool:
+				table := NewHashChainTable[bool](tt.maxSize)
+				for i, value := range tt.insertValues {
+					err := table.Insert(value.(bool))
+					if tt.expectedErrors[i] != nil {
+						assert.ErrorIs(t, err, tt.expectedErrors[i])
+					} else {
+						assert.NoError(t, err)
+					}
+				}
+				assert.Equal(t, tt.finalSize, table.Size())
+			}
+		})
+	}
+}
+
+func TestHashChainTable_Search(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxSize       int64
+		insertValues  []string
+		searchValue   string
+		expectFound   bool
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name:         "search in empty table",
+			maxSize:      10,
+			insertValues: []string{},
+			searchValue:  "apple",
+			expectFound:  false,
+			expectError:  false,
+		},
+		{
+			name:         "search existing value",
+			maxSize:      10,
+			insertValues: []string{"apple", "banana", "cherry"},
+			searchValue:  "banana",
+			expectFound:  true,
+			expectError:  false,
+		},
+		{
+			name:         "search non-existing value",
+			maxSize:      10,
+			insertValues: []string{"apple", "banana", "cherry"},
+			searchValue:  "grape",
+			expectFound:  false,
+			expectError:  false,
+		},
+		{
+			name:         "search with collision",
+			maxSize:      2, // Small table to force collisions
+			insertValues: []string{"a", "b", "c", "d"},
+			searchValue:  "c",
+			expectFound:  true,
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewHashChainTable[string](tt.maxSize)
+
+			// Insert values
+			for _, value := range tt.insertValues {
+				err := table.Insert(value)
+				require.NoError(t, err)
+			}
+
+			// Search for value
+			node, err := table.Search(tt.searchValue)
+
+			if tt.expectError {
+				assert.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				if tt.expectFound {
+					require.NotNil(t, node)
+					assert.Equal(t, tt.searchValue, node.Value)
+				} else {
+					assert.Nil(t, node)
+				}
+			}
+		})
+	}
+}
+
+func TestHashChainTable_Search_UnsupportedType(t *testing.T) {
+	table := NewHashChainTable[bool](10)
+
+	_, err := table.Search(true)
+	assert.ErrorIs(t, err, ErrorUnsupportedValueType)
+}
+
+func TestHashChainTable_Delete(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxSize       int64
+		insertValues  []string
+		deleteValue   string
+		expectError   bool
+		expectedError error
+		finalSize     int
+	}{
+		{
+			name:         "delete from empty table",
+			maxSize:      10,
+			insertValues: []string{},
+			deleteValue:  "apple",
+			expectError:  false,
+			finalSize:    0,
+		},
+		{
+			name:         "delete existing value",
+			maxSize:      10,
+			insertValues: []string{"apple", "banana", "cherry"},
+			deleteValue:  "banana",
+			expectError:  false,
+			finalSize:    2,
+		},
+		{
+			name:         "delete non-existing value",
+			maxSize:      10,
+			insertValues: []string{"apple", "banana", "cherry"},
+			deleteValue:  "grape",
+			expectError:  false, // Delete returns nil for non-existing values
+			finalSize:    3,
+		},
+		{
+			name:         "delete with collision",
+			maxSize:      2, // Small table to force collisions
+			insertValues: []string{"a", "b", "c", "d"},
+			deleteValue:  "c",
+			expectError:  false,
+			finalSize:    3,
+		},
+		{
+			name:         "delete all from single bucket",
+			maxSize:      1, // Force all values into one bucket
+			insertValues: []string{"a", "b", "c"},
+			deleteValue:  "b",
+			expectError:  false,
+			finalSize:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewHashChainTable[string](tt.maxSize)
+
+			// Insert values
+			for _, value := range tt.insertValues {
+				err := table.Insert(value)
+				require.NoError(t, err)
+			}
+
+			// Delete value
+			err := table.Delete(tt.deleteValue)
+
+			if tt.expectError {
+				assert.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.finalSize, table.Size())
+
+			// Verify the value is actually deleted
+			if !tt.expectError && tt.finalSize < len(tt.insertValues) {
+				node, err := table.Search(tt.deleteValue)
+				assert.NoError(t, err)
+				assert.Nil(t, node)
+			}
+		})
+	}
+}
+
+func TestHashChainTable_Delete_UnsupportedType(t *testing.T) {
+	table := NewHashChainTable[bool](10)
+
+	err := table.Delete(true)
+	assert.ErrorIs(t, err, ErrorUnsupportedValueType)
+}
+
+func TestHashChainTable_Concurrency(t *testing.T) {
+	table := NewHashChainTable[int](100)
+
+	// Test concurrent insertions
+	done := make(chan bool)
+
+	// Insert values concurrently
+	for i := 0; i < 10; i++ {
+		go func(start int) {
+			for j := start * 10; j < (start+1)*10; j++ {
+				err := table.Insert(j)
+				assert.NoError(t, err)
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify all values were inserted
+	assert.Equal(t, 100, table.Size())
+
+	// Verify all values can be found
+	for i := 0; i < 100; i++ {
+		node, err := table.Search(i)
+		assert.NoError(t, err)
+		assert.NotNil(t, node)
+		assert.Equal(t, i, node.Value)
+	}
+}
+
+func TestHashChainTable_GetHash(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     interface{}
+		expectErr bool
+	}{
+		{"hash string", "hello", false},
+		{"hash int", 42, false},
+		{"hash float64", 3.14, false},
+		{"hash unsupported bool", true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switch v := tt.value.(type) {
+			case string:
+				table := NewHashChainTable[string](10)
+				hash, err := table.getHash(v)
+				if tt.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotZero(t, hash)
+				}
+			case int:
+				table := NewHashChainTable[int](10)
+				hash, err := table.getHash(v)
+				if tt.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotZero(t, hash)
+				}
+			case float64:
+				table := NewHashChainTable[float64](10)
+				hash, err := table.getHash(v)
+				if tt.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotZero(t, hash)
+				}
+			case bool:
+				table := NewHashChainTable[bool](10)
+				hash, err := table.getHash(v)
+				if tt.expectErr {
+					assert.ErrorIs(t, err, ErrorUnsupportedValueType)
+					assert.Zero(t, hash)
+				} else {
+					assert.NoError(t, err)
+					assert.NotZero(t, hash)
+				}
+			}
+		})
+	}
+}
+
+func TestHashChainTable_HashConsistency(t *testing.T) {
+	table := NewHashChainTable[string](10)
+
+	testValues := []string{"apple", "banana", "cherry", "date"}
+
+	// Get hashes multiple times and verify consistency
+	for _, value := range testValues {
+		hash1, err1 := table.getHash(value)
+		require.NoError(t, err1)
+
+		hash2, err2 := table.getHash(value)
+		require.NoError(t, err2)
+
+		assert.Equal(t, hash1, hash2, "Hash should be consistent for value: %s", value)
+	}
+}
+
+func TestHashChainTable_CompleteWorkflow(t *testing.T) {
+	// Test a complete workflow: insert, search, delete
+	table := NewHashChainTable[string](5)
+	values := []string{"apple", "banana", "cherry", "date", "elderberry"}
+
+	// Insert all values
+	for _, value := range values {
+		err := table.Insert(value)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, len(values), table.Size())
+
+	// Search for all values
+	for _, value := range values {
+		node, err := table.Search(value)
+		require.NoError(t, err)
+		require.NotNil(t, node)
+		assert.Equal(t, value, node.Value)
+	}
+
+	// Delete some values
+	deleteValues := []string{"banana", "date"}
+	for _, value := range deleteValues {
+		err := table.Delete(value)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, len(values)-len(deleteValues), table.Size())
+
+	// Verify deleted values are gone
+	for _, value := range deleteValues {
+		node, err := table.Search(value)
+		require.NoError(t, err)
+		assert.Nil(t, node)
+	}
+
+	// Verify remaining values are still there
+	remainingValues := []string{"apple", "cherry", "elderberry"}
+	for _, value := range remainingValues {
+		node, err := table.Search(value)
+		require.NoError(t, err)
+		require.NotNil(t, node)
+		assert.Equal(t, value, node.Value)
+	}
+}

--- a/workbench/go/pkg/hash_table/hash_table_test.go
+++ b/workbench/go/pkg/hash_table/hash_table_test.go
@@ -1,4 +1,4 @@
-package hash_table
+package hashtable
 
 import (
 	"testing"

--- a/workbench/go/pkg/hash_table/hash_table_test.go
+++ b/workbench/go/pkg/hash_table/hash_table_test.go
@@ -3,6 +3,7 @@ package hash_table
 import (
 	"testing"
 
+	l "github.com/haru-256/ctci-6th-edition/pkg/linked_list"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,101 +82,117 @@ func TestHashChainTable_Size(t *testing.T) {
 	}
 }
 
-func TestHashChainTable_Insert(t *testing.T) {
+func TestHashChainTable_Insert_Strings(t *testing.T) {
 	tests := []struct {
 		name           string
 		maxSize        int64
-		insertValues   []interface{}
+		insertValues   []string
 		expectedErrors []error
 		finalSize      int
 	}{
 		{
 			name:           "insert strings",
 			maxSize:        10,
-			insertValues:   []interface{}{"apple", "banana", "cherry"},
+			insertValues:   []string{"apple", "banana", "cherry"},
 			expectedErrors: []error{nil, nil, nil},
 			finalSize:      3,
 		},
 		{
-			name:           "insert integers",
+			name:           "insert duplicate strings",
 			maxSize:        5,
-			insertValues:   []interface{}{1, 2, 3, 4, 5},
-			expectedErrors: []error{nil, nil, nil, nil, nil},
-			finalSize:      5,
-		},
-		{
-			name:           "insert floats",
-			maxSize:        3,
-			insertValues:   []interface{}{1.1, 2.2, 3.3},
-			expectedErrors: []error{nil, nil, nil},
-			finalSize:      3,
-		},
-		{
-			name:           "insert duplicate",
-			maxSize:        5,
-			insertValues:   []interface{}{"apple", "banana", "apple"},
+			insertValues:   []string{"apple", "banana", "apple"},
 			expectedErrors: []error{nil, nil, ErrorAlreadyExists},
 			finalSize:      2,
-		},
-		{
-			name:           "unsupported type",
-			maxSize:        5,
-			insertValues:   []interface{}{true}, // bool is not supported
-			expectedErrors: []error{ErrorUnsupportedValueType},
-			finalSize:      0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			switch tt.insertValues[0].(type) {
-			case string:
-				table := NewHashChainTable[string](tt.maxSize)
-				for i, value := range tt.insertValues {
-					err := table.Insert(value.(string))
-					if tt.expectedErrors[i] != nil {
-						assert.ErrorIs(t, err, tt.expectedErrors[i])
-					} else {
-						assert.NoError(t, err)
-					}
+			table := NewHashChainTable[string](tt.maxSize)
+			for i, value := range tt.insertValues {
+				err := table.Insert(value)
+				if tt.expectedErrors[i] != nil {
+					assert.ErrorIs(t, err, tt.expectedErrors[i])
+				} else {
+					assert.NoError(t, err)
 				}
-				assert.Equal(t, tt.finalSize, table.Size())
-			case int:
-				table := NewHashChainTable[int](tt.maxSize)
-				for i, value := range tt.insertValues {
-					err := table.Insert(value.(int))
-					if tt.expectedErrors[i] != nil {
-						assert.ErrorIs(t, err, tt.expectedErrors[i])
-					} else {
-						assert.NoError(t, err)
-					}
-				}
-				assert.Equal(t, tt.finalSize, table.Size())
-			case float64:
-				table := NewHashChainTable[float64](tt.maxSize)
-				for i, value := range tt.insertValues {
-					err := table.Insert(value.(float64))
-					if tt.expectedErrors[i] != nil {
-						assert.ErrorIs(t, err, tt.expectedErrors[i])
-					} else {
-						assert.NoError(t, err)
-					}
-				}
-				assert.Equal(t, tt.finalSize, table.Size())
-			case bool:
-				table := NewHashChainTable[bool](tt.maxSize)
-				for i, value := range tt.insertValues {
-					err := table.Insert(value.(bool))
-					if tt.expectedErrors[i] != nil {
-						assert.ErrorIs(t, err, tt.expectedErrors[i])
-					} else {
-						assert.NoError(t, err)
-					}
-				}
-				assert.Equal(t, tt.finalSize, table.Size())
 			}
+			assert.Equal(t, tt.finalSize, table.Size())
 		})
 	}
+}
+
+func TestHashChainTable_Insert_Integers(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxSize        int64
+		insertValues   []int
+		expectedErrors []error
+		finalSize      int
+	}{
+		{
+			name:           "insert integers",
+			maxSize:        5,
+			insertValues:   []int{1, 2, 3, 4, 5},
+			expectedErrors: []error{nil, nil, nil, nil, nil},
+			finalSize:      5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewHashChainTable[int](tt.maxSize)
+			for i, value := range tt.insertValues {
+				err := table.Insert(value)
+				if tt.expectedErrors[i] != nil {
+					assert.ErrorIs(t, err, tt.expectedErrors[i])
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+			assert.Equal(t, tt.finalSize, table.Size())
+		})
+	}
+}
+
+func TestHashChainTable_Insert_Floats(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxSize        int64
+		insertValues   []float64
+		expectedErrors []error
+		finalSize      int
+	}{
+		{
+			name:           "insert floats",
+			maxSize:        3,
+			insertValues:   []float64{1.1, 2.2, 3.3},
+			expectedErrors: []error{nil, nil, nil},
+			finalSize:      3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewHashChainTable[float64](tt.maxSize)
+			for i, value := range tt.insertValues {
+				err := table.Insert(value)
+				if tt.expectedErrors[i] != nil {
+					assert.ErrorIs(t, err, tt.expectedErrors[i])
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+			assert.Equal(t, tt.finalSize, table.Size())
+		})
+	}
+}
+
+func TestHashChainTable_Insert_UnsupportedType(t *testing.T) {
+	table := NewHashChainTable[bool](5)
+	err := table.Insert(true)
+	assert.ErrorIs(t, err, ErrorUnsupportedValueType)
+	assert.Equal(t, 0, table.Size())
 }
 
 func TestHashChainTable_Search(t *testing.T) {
@@ -332,7 +349,8 @@ func TestHashChainTable_Delete(t *testing.T) {
 
 			// Verify the value is actually deleted
 			if !tt.expectError && tt.finalSize < len(tt.insertValues) {
-				node, err := table.Search(tt.deleteValue)
+				var node *l.Node[string]
+				node, err = table.Search(tt.deleteValue)
 				assert.NoError(t, err)
 				assert.Nil(t, node)
 			}

--- a/workbench/go/pkg/hash_table/hash_table_test.go
+++ b/workbench/go/pkg/hash_table/hash_table_test.go
@@ -285,12 +285,13 @@ func TestHashChainTable_Delete(t *testing.T) {
 		finalSize     int
 	}{
 		{
-			name:         "delete from empty table",
-			maxSize:      10,
-			insertValues: []string{},
-			deleteValue:  "apple",
-			expectError:  false,
-			finalSize:    0,
+			name:          "delete from empty table",
+			maxSize:       10,
+			insertValues:  []string{},
+			deleteValue:   "apple",
+			expectError:   true, // Delete returns ErrorNodeNotFound for non-existing values
+			expectedError: ErrorNodeNotFound,
+			finalSize:     0,
 		},
 		{
 			name:         "delete existing value",
@@ -301,12 +302,13 @@ func TestHashChainTable_Delete(t *testing.T) {
 			finalSize:    2,
 		},
 		{
-			name:         "delete non-existing value",
-			maxSize:      10,
-			insertValues: []string{"apple", "banana", "cherry"},
-			deleteValue:  "grape",
-			expectError:  false, // Delete returns nil for non-existing values
-			finalSize:    3,
+			name:          "delete non-existing value",
+			maxSize:       10,
+			insertValues:  []string{"apple", "banana", "cherry"},
+			deleteValue:   "grape",
+			expectError:   true, // Delete returns ErrorNodeNotFound for non-existing values
+			expectedError: ErrorNodeNotFound,
+			finalSize:     3,
 		},
 		{
 			name:         "delete with collision",

--- a/workbench/go/pkg/hash_table/hash_table_test.go
+++ b/workbench/go/pkg/hash_table/hash_table_test.go
@@ -398,61 +398,33 @@ func TestHashChainTable_Concurrency(t *testing.T) {
 	}
 }
 
-func TestHashChainTable_GetHash(t *testing.T) {
-	tests := []struct {
-		name      string
-		value     interface{}
-		expectErr bool
-	}{
-		{"hash string", "hello", false},
-		{"hash int", 42, false},
-		{"hash float64", 3.14, false},
-		{"hash unsupported bool", true, true},
-	}
+func testGetHash[T comparable](t *testing.T, value T, expectErr bool) {
+	t.Helper()
+	table := NewHashChainTable[T](10)
+	hash, err := table.getHash(value)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			switch v := tt.value.(type) {
-			case string:
-				table := NewHashChainTable[string](10)
-				hash, err := table.getHash(v)
-				if tt.expectErr {
-					assert.Error(t, err)
-				} else {
-					assert.NoError(t, err)
-					assert.NotZero(t, hash)
-				}
-			case int:
-				table := NewHashChainTable[int](10)
-				hash, err := table.getHash(v)
-				if tt.expectErr {
-					assert.Error(t, err)
-				} else {
-					assert.NoError(t, err)
-					assert.NotZero(t, hash)
-				}
-			case float64:
-				table := NewHashChainTable[float64](10)
-				hash, err := table.getHash(v)
-				if tt.expectErr {
-					assert.Error(t, err)
-				} else {
-					assert.NoError(t, err)
-					assert.NotZero(t, hash)
-				}
-			case bool:
-				table := NewHashChainTable[bool](10)
-				hash, err := table.getHash(v)
-				if tt.expectErr {
-					assert.ErrorIs(t, err, ErrorUnsupportedValueType)
-					assert.Zero(t, hash)
-				} else {
-					assert.NoError(t, err)
-					assert.NotZero(t, hash)
-				}
-			}
-		})
+	if expectErr {
+		assert.ErrorIs(t, err, ErrorUnsupportedValueType)
+		assert.Zero(t, hash)
+	} else {
+		assert.NoError(t, err)
+		assert.NotZero(t, hash)
 	}
+}
+
+func TestHashChainTable_GetHash(t *testing.T) {
+	t.Run("hash string", func(t *testing.T) {
+		testGetHash(t, "hello", false)
+	})
+	t.Run("hash int", func(t *testing.T) {
+		testGetHash(t, 42, false)
+	})
+	t.Run("hash float64", func(t *testing.T) {
+		testGetHash(t, 3.14, false)
+	})
+	t.Run("hash unsupported bool", func(t *testing.T) {
+		testGetHash(t, true, true)
+	})
 }
 
 func TestHashChainTable_HashConsistency(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new, thread-safe hash table implementation using chaining for collision resolution. The main changes include moving the hash table code to a new package, adding support for generic types, and improving performance and safety for concurrent access.

**Hash table implementation and API:**

* Added a new `hash_table` package with a generic `HashChainTable[T comparable]` type that supports thread-safe operations (insert, search, delete) using chaining via linked lists. (`workbench/go/pkg/hash_table/hash_table.go`, [workbench/go/pkg/hash_table/hash_table.goR1-R173](diffhunk://#diff-1364ff5c1cdc1d9d94e86f6e90e98dbea87c2f1bf5a04c98fe63260a64d8b50cR1-R173))
* Provided error handling for duplicate inserts and unsupported value types, supporting `int`, `float64`, and `string` for hashing. (`workbench/go/pkg/hash_table/hash_table.go`, [workbench/go/pkg/hash_table/hash_table.goR1-R173](diffhunk://#diff-1364ff5c1cdc1d9d94e86f6e90e98dbea87c2f1bf5a04c98fe63260a64d8b50cR1-R173))

**Performance and concurrency improvements:**

* Utilized a `sync.Pool` of FNV-1a hashers to reduce allocation overhead and improve concurrent performance. (`workbench/go/pkg/hash_table/hash_table.go`, [workbench/go/pkg/hash_table/hash_table.goR1-R173](diffhunk://#diff-1364ff5c1cdc1d9d94e86f6e90e98dbea87c2f1bf5a04c98fe63260a64d8b50cR1-R173))
* Protected all public methods (`Insert`, `Search`, `Delete`, `Size`) with appropriate mutexes for thread safety. (`workbench/go/pkg/hash_table/hash_table.go`, [workbench/go/pkg/hash_table/hash_table.goR1-R173](diffhunk://#diff-1364ff5c1cdc1d9d94e86f6e90e98dbea87c2f1bf5a04c98fe63260a64d8b50cR1-R173))

**Project structure changes:**

* Moved the hash table implementation from the `hash` package to the new `hash_table` package for better organization and clarity. (`workbench/go/pkg/hash/hash_table.go`, [[1]](diffhunk://#diff-baa303cbfa12c9ce956dd4df2d9146b3a5a77a2d032bb7ef3b845d5555f677abL1); `workbench/go/pkg/hash_table/hash_table.go`, [[2]](diffhunk://#diff-1364ff5c1cdc1d9d94e86f6e90e98dbea87c2f1bf5a04c98fe63260a64d8b50cR1-R173)