### PR TITLE
Enhance thread safety and concurrency support across data structures

### DIFF
--- a/workbench/go/pkg/hash_table/hash_table.go
+++ b/workbench/go/pkg/hash_table/hash_table.go
@@ -138,7 +138,7 @@ func (table *HashChainTable[T]) Delete(value T) error {
 	}
 
 	table.size--
-	if table.Table[index].Head == nil { // if list is empty, remove bucket for garbage collection
+	if table.Table[index].Head() == nil { // if list is empty, remove bucket for garbage collection
 		table.Table[index] = nil
 	}
 	return nil

--- a/workbench/go/pkg/heap/heap.go
+++ b/workbench/go/pkg/heap/heap.go
@@ -292,7 +292,9 @@ func HeapSort[T cmp.Ordered](arr []*T) ([]*T, error) {
 	for i := heapSize - 1; i > 0; i-- {
 		heap.swap(0, i)
 		heapSize--
-		_ = heap.downHeapWithSize(0, heapSize)
+		if downErr := heap.downHeapWithSize(0, heapSize); downErr != nil {
+			return nil, downErr
+		}
 	}
 	return heap.items, nil
 }

--- a/workbench/go/pkg/heap/heap.go
+++ b/workbench/go/pkg/heap/heap.go
@@ -98,6 +98,9 @@ func (h *Heap[T]) upHeap(index int) {
 func (h *Heap[T]) UpHeap(index int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if index < 0 || index >= len(h.items) {
+		return // Or return an error
+	}
 	h.upHeap(index)
 }
 

--- a/workbench/go/pkg/heap/heap_test.go
+++ b/workbench/go/pkg/heap/heap_test.go
@@ -748,9 +748,9 @@ func performMixedOperations(heap *Heap[int], goroutineID, numOps int) error {
 			}
 		} else {
 			// Peek operation (ignore errors for empty heap)
-			if _, err := heap.Peek(); err != nil {
-				return err
-			}
+if _, err := heap.Peek(); err != nil && err != ErrorIsEmpty {
+	return err
+}
 		}
 	}
 	return nil

--- a/workbench/go/pkg/heap/heap_test.go
+++ b/workbench/go/pkg/heap/heap_test.go
@@ -748,9 +748,9 @@ func performMixedOperations(heap *Heap[int], goroutineID, numOps int) error {
 			}
 		} else {
 			// Peek operation (ignore errors for empty heap)
-if _, err := heap.Peek(); err != nil && err != ErrorIsEmpty {
-	return err
-}
+			if _, err := heap.Peek(); err != nil && err != ErrorIsEmpty {
+				return err
+			}
 		}
 	}
 	return nil

--- a/workbench/go/pkg/heap/heap_test.go
+++ b/workbench/go/pkg/heap/heap_test.go
@@ -67,10 +67,10 @@ func TestMinHeap_Operations(t *testing.T) {
 	heap := NewMinHeap[int]()
 
 	// Insert elements
-	heap.Insert(30)
-	heap.Insert(10)
-	heap.Insert(20)
-	heap.Insert(5)
+	require.NoError(t, heap.Insert(30))
+	require.NoError(t, heap.Insert(10))
+	require.NoError(t, heap.Insert(20))
+	require.NoError(t, heap.Insert(5))
 
 	// Root should be minimum (5)
 	min, err := heap.Peek()
@@ -91,7 +91,7 @@ func TestHeap_Insert(t *testing.T) {
 	heap := NewHeap[int](intCmp)
 
 	// Test inserting single element
-	heap.Insert(10)
+	require.NoError(t, heap.Insert(10))
 	assert.Equal(t, 1, heap.Size(), "Expected size 1")
 
 	top, err := heap.Peek()
@@ -99,9 +99,9 @@ func TestHeap_Insert(t *testing.T) {
 	assert.Equal(t, 10, *top, "Expected 10")
 
 	// Test inserting multiple elements
-	heap.Insert(20)
-	heap.Insert(5)
-	heap.Insert(15)
+	require.NoError(t, heap.Insert(20))
+	require.NoError(t, heap.Insert(5))
+	require.NoError(t, heap.Insert(15))
 
 	assert.Equal(t, 4, heap.Size(), "Expected size 4")
 
@@ -118,7 +118,7 @@ func TestMaxHeap_HeapProperty(t *testing.T) {
 	values := []int{10, 30, 20, 40, 50, 15, 25}
 
 	for _, v := range values {
-		heap.Insert(v)
+		require.NoError(t, heap.Insert(v))
 	}
 
 	// Get items using GetItems() to verify heap property
@@ -151,10 +151,10 @@ func TestMaxHeap_Pop(t *testing.T) {
 	assert.Equal(t, ErrorIsEmpty, err, "Expected ErrorIsEmpty")
 
 	// Insert elements and test pop
-	heap.Insert(10)
-	heap.Insert(20)
-	heap.Insert(5)
-	heap.Insert(15)
+	require.NoError(t, heap.Insert(10))
+	require.NoError(t, heap.Insert(20))
+	require.NoError(t, heap.Insert(5))
+	require.NoError(t, heap.Insert(15))
 
 	// Pop should return elements in descending order
 	expectedValues := []int{20, 15, 10, 5}
@@ -181,12 +181,12 @@ func TestMaxHeap_Max(t *testing.T) {
 	assert.Equal(t, ErrorIsEmpty, err, "Expected ErrorIsEmpty")
 
 	// Insert elements and test max
-	heap.Insert(10)
+	require.NoError(t, heap.Insert(10))
 	max, err := heap.Peek()
 	require.NoError(t, err, "Unexpected error")
 	assert.Equal(t, 10, *max, "Expected max 10")
 
-	heap.Insert(20)
+	require.NoError(t, heap.Insert(20))
 	max, err = heap.Peek()
 	require.NoError(t, err, "Unexpected error")
 	assert.Equal(t, 20, *max, "Expected max 20")
@@ -254,7 +254,8 @@ func TestBuildMaxHeap(t *testing.T) {
 	}
 
 	// Build max heap from array
-	heap := BuildMaxHeap(itemPtrs)
+	heap, err := BuildMaxHeap(itemPtrs)
+	require.NoError(t, err)
 
 	// Verify max heap property
 	for i := 0; i < heap.Size()/2; i++ {
@@ -290,7 +291,8 @@ func TestBuildMinHeap(t *testing.T) {
 	}
 
 	// Build min heap from array
-	heap := BuildMinHeap(itemPtrs)
+	heap, err := BuildMinHeap(itemPtrs)
+	require.NoError(t, err)
 
 	// Verify min heap property
 	for i := 0; i < heap.Size()/2; i++ {
@@ -326,7 +328,8 @@ func TestHeapSort(t *testing.T) {
 	}
 
 	// Perform heap sort
-	sorted := HeapSort(itemPtrs)
+	sorted, err := HeapSort(itemPtrs)
+	require.NoError(t, err)
 
 	// After heap sort, the array should be sorted in ascending order
 	expected := []int{10, 20, 30, 40, 50}
@@ -347,7 +350,8 @@ func TestHeapSort_LargerDataset(t *testing.T) {
 	}
 
 	// Perform heap sort
-	sorted := HeapSort(itemPtrs)
+	sorted, err := HeapSort(itemPtrs)
+	require.NoError(t, err)
 
 	// After heap sort, the array should be sorted in ascending order
 	expected := []int{1, 5, 11, 12, 22, 25, 30, 34, 45, 55, 60, 64, 77, 78, 90}
@@ -360,7 +364,8 @@ func TestHeapSort_EmptyHeap(t *testing.T) {
 	// Test heap sort on empty array
 	var itemPtrs []*int
 
-	sorted := HeapSort(itemPtrs)
+	sorted, err := HeapSort(itemPtrs)
+	require.NoError(t, err)
 
 	assert.Empty(t, sorted, "Expected empty array after HeapSort")
 }
@@ -370,7 +375,8 @@ func TestHeapSort_SingleElement(t *testing.T) {
 	value := 42
 	itemPtrs := []*int{&value}
 
-	sorted := HeapSort(itemPtrs)
+	sorted, err := HeapSort(itemPtrs)
+	require.NoError(t, err)
 
 	assert.Len(t, sorted, 1, "Expected size 1 for single element array after HeapSort")
 	assert.Equal(t, 42, *sorted[0], "Expected 42")
@@ -379,9 +385,9 @@ func TestHeapSort_SingleElement(t *testing.T) {
 func TestMaxHeap_WithDifferentTypes(t *testing.T) {
 	// Test with string values
 	stringHeap := NewHeap[string](stringCmp)
-	stringHeap.Insert("zebra")
-	stringHeap.Insert("apple")
-	stringHeap.Insert("banana")
+	require.NoError(t, stringHeap.Insert("zebra"))
+	require.NoError(t, stringHeap.Insert("apple"))
+	require.NoError(t, stringHeap.Insert("banana"))
 
 	// Root should be "zebra" (lexicographically largest)
 	max, err := stringHeap.Peek()
@@ -390,9 +396,9 @@ func TestMaxHeap_WithDifferentTypes(t *testing.T) {
 
 	// Test with float64 values
 	floatHeap := NewHeap[float64](float64Cmp)
-	floatHeap.Insert(3.14)
-	floatHeap.Insert(2.71)
-	floatHeap.Insert(1.41)
+	require.NoError(t, floatHeap.Insert(3.14))
+	require.NoError(t, floatHeap.Insert(2.71))
+	require.NoError(t, floatHeap.Insert(1.41))
 
 	// Root should be 3.14 (largest)
 	max2, err := floatHeap.Peek()
@@ -407,7 +413,7 @@ func TestMaxHeap_IntegrationTest(t *testing.T) {
 	elements := []int{50, 30, 70, 20, 40, 60, 80}
 
 	for _, elem := range elements {
-		heap.Insert(elem)
+		require.NoError(t, heap.Insert(elem))
 	}
 
 	// Verify size
@@ -447,9 +453,9 @@ func TestMaxHeap_CustomType(t *testing.T) {
 	heap := NewHeap[Person](personCmpByAge)
 
 	// Insert people
-	heap.Insert(Person{Name: "Alice", Age: 30})
-	heap.Insert(Person{Name: "Bob", Age: 25})
-	heap.Insert(Person{Name: "Charlie", Age: 35})
+	require.NoError(t, heap.Insert(Person{Name: "Alice", Age: 30}))
+	require.NoError(t, heap.Insert(Person{Name: "Bob", Age: 25}))
+	require.NoError(t, heap.Insert(Person{Name: "Charlie", Age: 35}))
 
 	// Max should be Charlie (oldest)
 	max, err := heap.Peek()
@@ -482,9 +488,9 @@ func TestMaxHeap_WithNodeType(t *testing.T) {
 	heap := NewHeap[Node[int, string]](nodeCmp)
 
 	// Insert nodes
-	heap.Insert(Node[int, string]{Key: 10, Value: "ten"})
-	heap.Insert(Node[int, string]{Key: 20, Value: "twenty"})
-	heap.Insert(Node[int, string]{Key: 5, Value: "five"})
+	require.NoError(t, heap.Insert(Node[int, string]{Key: 10, Value: "ten"}))
+	require.NoError(t, heap.Insert(Node[int, string]{Key: 20, Value: "twenty"}))
+	require.NoError(t, heap.Insert(Node[int, string]{Key: 5, Value: "five"}))
 
 	// Max should be node with key 20
 	max, err := heap.Peek()
@@ -499,7 +505,7 @@ func BenchmarkMaxHeap_Insert(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		heap.Insert(i)
+		_ = heap.Insert(i)
 	}
 }
 
@@ -507,7 +513,7 @@ func BenchmarkMaxHeap_Pop(b *testing.B) {
 	// Pre-populate heap
 	heap := NewMaxHeap[int]()
 	for i := 0; i < b.N; i++ {
-		heap.Insert(i)
+		_ = heap.Insert(i)
 	}
 
 	b.ResetTimer()
@@ -528,7 +534,7 @@ func BenchmarkHeapSort(b *testing.B) {
 		}
 
 		b.StartTimer()
-		HeapSort(itemPtrs)
+		_, _ = HeapSort(itemPtrs)
 	}
 }
 
@@ -549,7 +555,7 @@ func TestHeap_ConcurrentInsertPop(t *testing.T) {
 		g.Go(func() error {
 			for j := 0; j < numOpsPerGoroutine; j++ {
 				value := goroutineID*numOpsPerGoroutine + j
-				heap.Insert(value)
+				_ = heap.Insert(value)
 			}
 			return nil
 		})
@@ -571,7 +577,7 @@ func TestHeap_ConcurrentInsertPop(t *testing.T) {
 	require.NoError(t, err, "All goroutines should complete without error")
 
 	// Verify no deadlocks occurred by checking heap is still functional
-	heap.Insert(999)
+	require.NoError(t, heap.Insert(999))
 	top, err := heap.Peek()
 	require.NoError(t, err, "Heap should still be functional after concurrent operations")
 	require.NotNil(t, top, "Should be able to peek after concurrent operations")
@@ -586,7 +592,7 @@ func TestHeap_ConcurrentReads(t *testing.T) {
 	// Populate heap with test data
 	testData := []int{50, 30, 70, 20, 40, 60, 80}
 	for _, val := range testData {
-		heap.Insert(val)
+		require.NoError(t, heap.Insert(val))
 	}
 
 	const numReaders = 20
@@ -651,7 +657,7 @@ func TestHeap_ConcurrentUpDownHeap(t *testing.T) {
 	// Populate heap with some initial data to have valid indices
 	initialData := []int{10, 20, 30, 40, 50, 60, 70, 80, 90, 100}
 	for _, val := range initialData {
-		heap.Insert(val)
+		require.NoError(t, heap.Insert(val))
 	}
 
 	const numGoroutines = 10
@@ -660,63 +666,101 @@ func TestHeap_ConcurrentUpDownHeap(t *testing.T) {
 	ctx := context.Background()
 	g, _ := errgroup.WithContext(ctx)
 
-	// Concurrent UpHeap operations
-	for i := 0; i < numGoroutines; i++ {
-		g.Go(func() error {
-			for j := 0; j < numOpsPerGoroutine; j++ {
-				// Use valid indices (heap size may change during concurrent operations)
-				size := heap.Size()
-				if size > 0 {
-					index := j % size
-					heap.UpHeap(index)
-				}
-			}
-			return nil
-		})
-	}
-
-	// Concurrent DownHeap operations
-	for i := 0; i < numGoroutines; i++ {
-		g.Go(func() error {
-			for j := 0; j < numOpsPerGoroutine; j++ {
-				// Use valid indices (heap size may change during concurrent operations)
-				size := heap.Size()
-				if size > 0 {
-					index := j % size
-					heap.DownHeap(index)
-				}
-			}
-			return nil
-		})
-	}
-
-	// Mixed operations (Insert/Pop) to simulate real-world usage
-	for i := 0; i < numGoroutines; i++ {
-		goroutineID := i
-		g.Go(func() error {
-			for j := 0; j < numOpsPerGoroutine; j++ {
-				if j%2 == 0 {
-					// Insert operation
-					value := goroutineID*1000 + j
-					heap.Insert(value)
-				} else {
-					// Pop operation (ignore errors for empty heap)
-					if _, err := heap.Peek(); err != nil {
-						return err
-					}
-				}
-			}
-			return nil
-		})
-	}
+	// Start concurrent operations
+	startConcurrentUpHeap(g, heap, numGoroutines, numOpsPerGoroutine)
+	startConcurrentDownHeap(g, heap, numGoroutines, numOpsPerGoroutine)
+	startMixedOperations(g, heap, numGoroutines, numOpsPerGoroutine)
 
 	// Wait for all operations to complete
 	err := g.Wait()
 	require.NoError(t, err, "All concurrent operations should complete without error")
 
+	// Verify heap functionality after concurrent operations
+	verifyHeapIntegrityAfterConcurrency(t, heap)
+}
+
+// startConcurrentUpHeap launches goroutines that perform UpHeap operations
+func startConcurrentUpHeap(g *errgroup.Group, heap *Heap[int], numGoroutines, numOpsPerGoroutine int) {
+	for i := 0; i < numGoroutines; i++ {
+		g.Go(func() error {
+			return performUpHeapOperations(heap, numOpsPerGoroutine)
+		})
+	}
+}
+
+// performUpHeapOperations executes UpHeap operations for a single goroutine
+func performUpHeapOperations(heap *Heap[int], numOps int) error {
+	for j := 0; j < numOps; j++ {
+		// Use valid indices (heap size may change during concurrent operations)
+		size := heap.Size()
+		if size > 0 {
+			index := j % size
+			if err := heap.UpHeap(index); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// startConcurrentDownHeap launches goroutines that perform DownHeap operations
+func startConcurrentDownHeap(g *errgroup.Group, heap *Heap[int], numGoroutines, numOpsPerGoroutine int) {
+	for i := 0; i < numGoroutines; i++ {
+		g.Go(func() error {
+			return performDownHeapOperations(heap, numOpsPerGoroutine)
+		})
+	}
+}
+
+// performDownHeapOperations executes DownHeap operations for a single goroutine
+func performDownHeapOperations(heap *Heap[int], numOps int) error {
+	for j := 0; j < numOps; j++ {
+		// Use valid indices (heap size may change during concurrent operations)
+		size := heap.Size()
+		if size > 0 {
+			index := j % size
+			if err := heap.DownHeap(index); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// startMixedOperations launches goroutines that perform mixed Insert/Peek operations
+func startMixedOperations(g *errgroup.Group, heap *Heap[int], numGoroutines, numOpsPerGoroutine int) {
+	for i := 0; i < numGoroutines; i++ {
+		goroutineID := i
+		g.Go(func() error {
+			return performMixedOperations(heap, goroutineID, numOpsPerGoroutine)
+		})
+	}
+}
+
+// performMixedOperations executes mixed Insert/Peek operations for a single goroutine
+func performMixedOperations(heap *Heap[int], goroutineID, numOps int) error {
+	for j := 0; j < numOps; j++ {
+		if j%2 == 0 {
+			// Insert operation
+			value := goroutineID*1000 + j
+			if err := heap.Insert(value); err != nil {
+				return err
+			}
+		} else {
+			// Peek operation (ignore errors for empty heap)
+			if _, err := heap.Peek(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// verifyHeapIntegrityAfterConcurrency checks that the heap maintains its properties after concurrent operations
+func verifyHeapIntegrityAfterConcurrency(t *testing.T, heap *Heap[int]) {
 	// Verify heap is still functional and maintains heap property
 	// Insert a known maximum value
-	heap.Insert(9999)
+	require.NoError(t, heap.Insert(9999))
 	top, err := heap.Peek()
 	require.NoError(t, err, "Heap should still be functional after concurrent UpHeap/DownHeap")
 	require.NotNil(t, top, "Peek should return a value")

--- a/workbench/go/pkg/linked_list/doc.go
+++ b/workbench/go/pkg/linked_list/doc.go
@@ -13,7 +13,18 @@ pointers for optimal performance at both ends of the list.
 - Head and tail pointers for optimal end operations
 - Linear search functionality with O(n) complexity
 - Proper memory management with garbage collection support
+- Thread-safe for concurrent use by multiple goroutines
 - Simple and intuitive API design
+
+# Thread Safety
+
+This implementation is thread-safe and can be used concurrently by multiple goroutines.
+All public methods use appropriate mutex locking:
+- Read operations (Search) use RWMutex.RLock() for concurrent reads
+- Write operations (Prepend, Insert, Delete) use RWMutex.Lock() for exclusive access
+- The mutex prevents race conditions and ensures list consistency across goroutines
+
+No external synchronization is required when using this linked list from multiple goroutines.
 
 # Performance Characteristics
 
@@ -58,6 +69,32 @@ The list excels at scenarios where frequent insertion/deletion is needed with kn
 		log.Fatal(err)
 	}
 	// List now contains: 10 <-> 25 <-> 30
+
+# Concurrent Usage
+
+The linked list is thread-safe and can be used safely from multiple goroutines
+without external synchronization:
+
+	// Multiple goroutines can safely operate on the same list
+	go func() {
+		for i := 0; i < 100; i++ {
+			list.Prepend(i)
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 50; i++ {
+			if node := list.Search(i); node != nil {
+				fmt.Printf("Found: %d\n", node.Value)
+			}
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 25; i++ {
+			list.Delete(i)
+		}
+	}()
 
 # Advanced Usage with Custom Types
 

--- a/workbench/go/pkg/linked_list/linked_list.go
+++ b/workbench/go/pkg/linked_list/linked_list.go
@@ -1,7 +1,9 @@
-// Package linked_list provides a generic doubly linked list implementation.
 package linked_list
 
-import "errors"
+import (
+	"errors"
+	"sync"
+)
 
 // ErrorNodeIsNil is returned when an operation is attempted on a nil Node.
 var (
@@ -11,24 +13,47 @@ var (
 )
 
 // LinkedList represents a generic doubly linked list.
-// It maintains pointers to both the head and tail nodes for efficient operations.
-// The list supports any comparable type T for its values.
+// The linked list is thread-safe and can be safely used by multiple goroutines concurrently.
+// Read operations use RWMutex.RLock() to allow concurrent reads,
+// while write operations use RWMutex.Lock() for exclusive access.
+// No external synchronization is required for concurrent use.
 type LinkedList[T comparable] struct {
-	Head *Node[T]
-	Tail *Node[T]
+	head  *Node[T]     // Points to the first node in the list
+	tail  *Node[T]     // Points to the last node in the list
+	mutex sync.RWMutex // Protects list operations for thread safety
 }
 
-// NewLinkedList creates and returns a new empty LinkedList.
-// The list is initialized with nil head and tail pointers.
+// NewLinkedList creates and returns a new empty doubly linked list.
+// The returned list is ready for use and properly initialized.
 func NewLinkedList[T comparable]() *LinkedList[T] {
 	return &LinkedList[T]{}
+}
+
+// Head returns the first node in the list or nil if the list is empty.
+// This method is thread-safe and uses read locking.
+func (l *LinkedList[T]) Head() *Node[T] {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	return l.head
+}
+
+// Tail returns the last node in the list or nil if the list is empty.
+// This method is thread-safe and uses read locking.
+func (l *LinkedList[T]) Tail() *Node[T] {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	return l.tail
 }
 
 // Search traverses the list from head to tail looking for a node with the specified value.
 // It returns a pointer to the first node found with the matching value, or nil if not found.
 // The search performs a linear traversal with O(n) time complexity.
+// This method is thread-safe and uses RLock to allow concurrent read access.
 func (l *LinkedList[T]) Search(value T) *Node[T] {
-	current := l.Head
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+
+	current := l.head
 	for current != nil {
 		if current.Value == value {
 			return current
@@ -41,16 +66,19 @@ func (l *LinkedList[T]) Search(value T) *Node[T] {
 // Prepend adds a new node with the specified value to the beginning of the list.
 // If the list is empty, the new node becomes both head and tail.
 // Otherwise, the new node is inserted before the current head and becomes the new head.
-// This operation has O(1) time complexity.
+// This operation has O(1) time complexity and is thread-safe using exclusive locking.
 func (l *LinkedList[T]) Prepend(value T) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	newNode := NewNode(value)
-	if l.Head == nil { // if list is empty
-		l.Head = newNode
-		l.Tail = newNode
+	if l.head == nil { // if list is empty
+		l.head = newNode
+		l.tail = newNode
 	} else {
-		newNode.Next = l.Head
-		l.Head.Prev = newNode
-		l.Head = newNode
+		newNode.Next = l.head
+		l.head.Prev = newNode
+		l.head = newNode
 	}
 }
 
@@ -58,7 +86,11 @@ func (l *LinkedList[T]) Prepend(value T) {
 // The 'after' parameter must not be nil, or ErrorNodeIsNil will be returned.
 // If 'after' is the current tail, the new node becomes the new tail.
 // This operation maintains all doubly-linked relationships and has O(1) time complexity.
+// This method is thread-safe using exclusive locking.
 func (l *LinkedList[T]) Insert(value T, after *Node[T]) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	if after == nil {
 		return ErrorNodeIsNil
 	}
@@ -67,11 +99,24 @@ func (l *LinkedList[T]) Insert(value T, after *Node[T]) error {
 		after.Next.Prev = newNode
 		newNode.Next = after.Next
 	} else {
-		l.Tail = newNode
+		l.tail = newNode
 	}
 	after.Next = newNode
 	newNode.Prev = after
 
+	return nil
+}
+
+// search is an internal helper method that searches for a node without locking.
+// This method assumes the caller already holds the appropriate lock.
+func (l *LinkedList[T]) search(value T) *Node[T] {
+	current := l.head
+	for current != nil {
+		if current.Value == value {
+			return current
+		}
+		current = current.Next
+	}
 	return nil
 }
 
@@ -80,20 +125,24 @@ func (l *LinkedList[T]) Insert(value T, after *Node[T]) error {
 // When a node is deleted, all links are properly updated to maintain list integrity.
 // If the deleted node was the head or tail, those pointers are updated accordingly.
 // This operation has O(n) time complexity due to the search phase.
+// This method is thread-safe using exclusive locking.
 func (l *LinkedList[T]) Delete(value T) error {
-	node := l.Search(value)
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	node := l.search(value)
 	if node == nil {
 		return ErrorNodeNotFound
 	}
 	if node.Prev != nil {
 		node.Prev.Next = node.Next
 	} else {
-		l.Head = node.Next
+		l.head = node.Next
 	}
 	if node.Next != nil {
 		node.Next.Prev = node.Prev
 	} else {
-		l.Tail = node.Prev
+		l.tail = node.Prev
 	}
 
 	// Help GC by breaking references from the deleted node.

--- a/workbench/go/pkg/linked_list/linked_list_test.go
+++ b/workbench/go/pkg/linked_list/linked_list_test.go
@@ -540,7 +540,6 @@ func TestLinkedList_MixedConcurrentOperations(t *testing.T) {
 	g.Go(func() error {
 		for i := 0; i < numOperations/4; i++ {
 			// Try to delete various values
-			_ = list.Delete(i%20 + 1) // Some may not exist anymore
 			if err := list.Delete(i%20 + 1); err != nil && err != ErrorNodeNotFound {
 				return err
 			}

--- a/workbench/go/pkg/priority_queue/priority_queue.go
+++ b/workbench/go/pkg/priority_queue/priority_queue.go
@@ -69,12 +69,12 @@ func NewPriorityQueue[T comparable](cmpFn func(a, b *Task[T]) int) *PriorityQueu
 //
 //	pq.Insert("urgent task", 10)
 //	pq.Insert("normal task", 5)
-func (pq *PriorityQueue[T]) Insert(item T, priority int) {
+func (pq *PriorityQueue[T]) Insert(item T, priority int) error {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 
 	task := NewTask(priority, item)
-	_ = pq.heap.Insert(task)
+	return pq.heap.Insert(task)
 }
 
 // Pop removes and returns the highest priority item from the queue.

--- a/workbench/go/pkg/priority_queue/priority_queue.go
+++ b/workbench/go/pkg/priority_queue/priority_queue.go
@@ -2,6 +2,7 @@ package priorityqueue
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/haru-256/ctci-6th-edition/pkg/heap"
@@ -17,6 +18,13 @@ var ErrNotFound = fmt.Errorf("item not found")
 // Items are ordered by priority (higher numbers have higher precedence) and by insertion time
 // for items with equal priority.
 //
+// Thread Safety:
+// The PriorityQueue is thread-safe for concurrent use by multiple goroutines.
+// It uses sync.RWMutex to coordinate access:
+// - All operations (Insert, Pop, Update) acquire exclusive locks to ensure consistency
+// - The mutex prevents race conditions during priority updates and heap modifications
+// - Safe coordination with the underlying thread-safe heap implementation
+//
 // Time complexities:
 //   - Insert: O(log n)
 //   - Pop: O(log n)
@@ -25,6 +33,7 @@ var ErrNotFound = fmt.Errorf("item not found")
 // Space complexity: O(n) where n is the number of items in the queue.
 type PriorityQueue[T comparable] struct {
 	heap *heap.Heap[Task[T]]
+	mu   sync.RWMutex
 }
 
 // NewPriorityQueue creates a new priority queue with the given comparison function.
@@ -51,6 +60,9 @@ func NewPriorityQueue[T comparable](cmpFn func(a, b *Task[T]) int) *PriorityQueu
 // Higher priority numbers indicate higher precedence. Items with the same priority
 // are ordered by insertion time (earlier items first).
 //
+// Thread Safety: This method is thread-safe. It acquires an exclusive lock during
+// the entire operation to ensure atomic insertion and heap rebalancing.
+//
 // Time complexity: O(log n)
 //
 // Example:
@@ -58,6 +70,9 @@ func NewPriorityQueue[T comparable](cmpFn func(a, b *Task[T]) int) *PriorityQueu
 //	pq.Insert("urgent task", 10)
 //	pq.Insert("normal task", 5)
 func (pq *PriorityQueue[T]) Insert(item T, priority int) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
 	task := NewTask(priority, item)
 	pq.heap.Insert(task)
 }
@@ -66,6 +81,9 @@ func (pq *PriorityQueue[T]) Insert(item T, priority int) {
 //
 // Returns the task with the highest priority, or an error if the queue is empty.
 // For items with equal priority, the item that was inserted first is returned.
+//
+// Thread Safety: This method is thread-safe. It acquires an exclusive lock during
+// the entire operation to ensure atomic removal and heap rebalancing.
 //
 // Time complexity: O(log n)
 //
@@ -78,6 +96,9 @@ func (pq *PriorityQueue[T]) Insert(item T, priority int) {
 //	}
 //	fmt.Printf("Processing: %s (priority: %d)\n", task.Value, task.Priority)
 func (pq *PriorityQueue[T]) Pop() (*Task[T], error) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
 	task, err := pq.heap.Pop()
 	if err != nil {
 		return nil, err
@@ -92,6 +113,10 @@ func (pq *PriorityQueue[T]) Pop() (*Task[T], error) {
 // If the item is not found, returns ErrNotFound.
 // If the new priority is the same as the current priority, no operation is performed.
 //
+// Thread Safety: This method is thread-safe. It acquires an exclusive lock during
+// the entire operation to ensure atomic search, priority update, and heap rebalancing.
+// The underlying heap's UpHeap/DownHeap methods are called safely within the lock.
+//
 // Time complexity: O(n) for searching + O(log n) for rebalancing
 //
 // Example:
@@ -101,6 +126,9 @@ func (pq *PriorityQueue[T]) Pop() (*Task[T], error) {
 //		fmt.Println("Task not found in queue")
 //	}
 func (pq *PriorityQueue[T]) Update(item T, priority int) error {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
 	// FIXME: The Update method has a time complexity of O(n) due to the linear scan to find the item.
 	var targetTask *Task[T]
 	var targetIdx int

--- a/workbench/go/pkg/priority_queue/priority_queue.go
+++ b/workbench/go/pkg/priority_queue/priority_queue.go
@@ -74,7 +74,7 @@ func (pq *PriorityQueue[T]) Insert(item T, priority int) {
 	defer pq.mu.Unlock()
 
 	task := NewTask(priority, item)
-	pq.heap.Insert(task)
+	_ = pq.heap.Insert(task)
 }
 
 // Pop removes and returns the highest priority item from the queue.
@@ -153,10 +153,14 @@ func (pq *PriorityQueue[T]) Update(item T, priority int) error {
 
 	if toLessThan {
 		// Priority decreased (was more, now lower), move down towards leaves
-		pq.heap.DownHeap(targetIdx)
+		if err := pq.heap.DownHeap(targetIdx); err != nil {
+			return err
+		}
 	} else if toLargerThan {
 		// Priority increased (was less, now higher), move up towards root
-		pq.heap.UpHeap(targetIdx)
+		if err := pq.heap.UpHeap(targetIdx); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/workbench/go/pkg/priority_queue/priority_queue_test.go
+++ b/workbench/go/pkg/priority_queue/priority_queue_test.go
@@ -27,7 +27,7 @@ type testUpdate struct {
 func setupPriorityQueue(items []testItem) *PriorityQueue[string] {
 	pq := NewPriorityQueue(PriorityCmp[string])
 	for _, item := range items {
-		pq.Insert(item.value, item.priority)
+		_ = pq.Insert(item.value, item.priority)
 	}
 	return pq
 }
@@ -379,7 +379,7 @@ func TestPriorityQueue_WithDifferentTypes(t *testing.T) {
 				}
 
 				for _, item := range items {
-					intPQ.Insert(item.value, item.priority)
+					_ = intPQ.Insert(item.value, item.priority)
 				}
 
 				expected := []struct {
@@ -419,7 +419,7 @@ func TestPriorityQueue_WithDifferentTypes(t *testing.T) {
 				}
 
 				for _, j := range jobs {
-					pq.Insert(j.job, j.priority)
+					_ = pq.Insert(j.job, j.priority)
 				}
 
 				expected := []struct {
@@ -512,7 +512,7 @@ func TestPriorityQueue_LargeDataset(t *testing.T) {
 
 			// Insert items
 			for i := 0; i < len(tt.priorities); i++ {
-				pq.Insert(tt.values[i], tt.priorities[i])
+				_ = pq.Insert(tt.values[i], tt.priorities[i])
 			}
 
 			require.Equal(t, len(tt.priorities), pq.heap.Size())
@@ -579,7 +579,7 @@ func BenchmarkPriorityQueue_Insert(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		pq.Insert(i, i%100)
+		_ = pq.Insert(i, i%100)
 	}
 }
 
@@ -588,7 +588,7 @@ func BenchmarkPriorityQueue_Pop(b *testing.B) {
 
 	// Pre-populate
 	for i := 0; i < b.N; i++ {
-		pq.Insert(i, i%100)
+		_ = pq.Insert(i, i%100)
 	}
 
 	b.ResetTimer()
@@ -603,7 +603,7 @@ func BenchmarkPriorityQueue_Update(b *testing.B) {
 
 	// Pre-populate with 1000 items
 	for i := 0; i < 1000; i++ {
-		pq.Insert(i, i)
+		_ = pq.Insert(i, i)
 	}
 
 	b.ResetTimer()
@@ -686,7 +686,7 @@ func TestPriorityQueue_ConcurrentInsertPop(t *testing.T) {
 			for j := 0; j < numOpsPerGoroutine; j++ {
 				task := fmt.Sprintf("task-%d-%d", goroutineID, j)
 				priority := goroutineID*numOpsPerGoroutine + j
-				pq.Insert(task, priority)
+				_ = pq.Insert(task, priority)
 			}
 			return nil
 		})
@@ -708,7 +708,7 @@ func TestPriorityQueue_ConcurrentInsertPop(t *testing.T) {
 	require.NoError(t, err, "All goroutines should complete without error")
 
 	// Verify no deadlocks occurred by checking priority queue is still functional
-	pq.Insert("test-task", 999)
+	require.NoError(t, pq.Insert("test-task", 999))
 	task, err := pq.Pop()
 	require.NoError(t, err, "Priority queue should still be functional after concurrent operations")
 	require.NotNil(t, task, "Should be able to pop after concurrent operations")
@@ -724,7 +724,7 @@ func TestPriorityQueue_ConcurrentUpdate(t *testing.T) {
 	// Pre-populate the queue with test items
 	testItems := []string{"task-1", "task-2", "task-3", "task-4", "task-5"}
 	for i, item := range testItems {
-		pq.Insert(item, i+1) // Initial priorities: 1, 2, 3, 4, 5
+		require.NoError(t, pq.Insert(item, i+1)) // Initial priorities: 1, 2, 3, 4, 5
 	}
 
 	const numGoroutines = 10
@@ -757,7 +757,7 @@ func TestPriorityQueue_ConcurrentUpdate(t *testing.T) {
 			for j := 0; j < 10; j++ {
 				// Insert new items
 				newItem := fmt.Sprintf("new-task-%d-%d", goroutineID, j)
-				pq.Insert(newItem, j+50)
+				_ = pq.Insert(newItem, j+50)
 
 				// Try to pop (might fail if queue is empty)
 				_, _ = pq.Pop()
@@ -771,7 +771,7 @@ func TestPriorityQueue_ConcurrentUpdate(t *testing.T) {
 	require.NoError(t, err, "All concurrent operations should complete without error")
 
 	// Verify the priority queue is still functional
-	pq.Insert("final-test", 1000)
+	require.NoError(t, pq.Insert("final-test", 1000))
 	task, err := pq.Pop()
 	require.NoError(t, err, "Priority queue should still be functional after concurrent updates")
 	require.NotNil(t, task, "Should be able to pop after concurrent operations")
@@ -817,7 +817,7 @@ func runProducerWorker(pq *PriorityQueue[string], workerID, numOperations int) e
 	for j := 0; j < numOperations; j++ {
 		task := fmt.Sprintf("producer-%d-task-%d", workerID, j)
 		priority := workerID*1000 + j
-		pq.Insert(task, priority)
+		_ = pq.Insert(task, priority)
 
 		// Occasionally update an existing task's priority
 		if j%10 == 0 && j > 0 {
@@ -848,7 +848,7 @@ func runConsumerWorker(pq *PriorityQueue[string], numOperations int) error {
 				// Occasionally re-insert a task with different priority
 				newTask := fmt.Sprintf("reprocessed-%s", task.Value)
 				newPriority := task.Priority - 100 // Lower priority for reprocessing
-				pq.Insert(newTask, newPriority)
+				_ = pq.Insert(newTask, newPriority)
 			}
 			processedCount++
 		}
@@ -862,7 +862,7 @@ func verifyPriorityQueueFunctionality(t *testing.T, pq *PriorityQueue[string]) {
 	// Insert some test items with known priorities
 	testPriorities := []int{100, 500, 50, 750, 25}
 	for i, priority := range testPriorities {
-		pq.Insert(fmt.Sprintf("final-test-%d", i), priority)
+		require.NoError(t, pq.Insert(fmt.Sprintf("final-test-%d", i), priority))
 	}
 
 	// Pop items and verify they come out in priority order (highest first)

--- a/workbench/go/pkg/priority_queue/priority_queue_test.go
+++ b/workbench/go/pkg/priority_queue/priority_queue_test.go
@@ -1,11 +1,15 @@
 package priorityqueue
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/haru-256/ctci-6th-edition/pkg/heap"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 // Helper types for test data
@@ -661,5 +665,234 @@ func TestPriorityQueue_DebugHeapBehavior(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.test(t)
 		})
+	}
+}
+
+// TestPriorityQueue_ConcurrentInsertPop tests thread safety of Insert and Pop operations
+// by running multiple goroutines concurrently using errgroup
+func TestPriorityQueue_ConcurrentInsertPop(t *testing.T) {
+	pq := NewPriorityQueue(PriorityCmp[string])
+
+	const numGoroutines = 10
+	const numOpsPerGoroutine = 50
+
+	ctx := context.Background()
+	g, _ := errgroup.WithContext(ctx)
+
+	// Launch goroutines that insert values
+	for i := 0; i < numGoroutines; i++ {
+		goroutineID := i
+		g.Go(func() error {
+			for j := 0; j < numOpsPerGoroutine; j++ {
+				task := fmt.Sprintf("task-%d-%d", goroutineID, j)
+				priority := goroutineID*numOpsPerGoroutine + j
+				pq.Insert(task, priority)
+			}
+			return nil
+		})
+	}
+
+	// Launch goroutines that pop values
+	for i := 0; i < numGoroutines; i++ {
+		g.Go(func() error {
+			for j := 0; j < numOpsPerGoroutine; j++ {
+				// Try to pop, but handle empty queue gracefully
+				_, _ = pq.Pop() // Ignore errors as queue might be empty
+			}
+			return nil
+		})
+	}
+
+	// Wait for all operations to complete
+	err := g.Wait()
+	require.NoError(t, err, "All goroutines should complete without error")
+
+	// Verify no deadlocks occurred by checking priority queue is still functional
+	pq.Insert("test-task", 999)
+	task, err := pq.Pop()
+	require.NoError(t, err, "Priority queue should still be functional after concurrent operations")
+	require.NotNil(t, task, "Should be able to pop after concurrent operations")
+	assert.Equal(t, "test-task", task.Value, "Inserted value should be popped")
+	assert.Equal(t, 999, task.Priority, "Priority should be preserved")
+}
+
+// TestPriorityQueue_ConcurrentUpdate tests thread safety of Update operations
+// by running multiple goroutines concurrently performing priority updates
+func TestPriorityQueue_ConcurrentUpdate(t *testing.T) {
+	pq := NewPriorityQueue(PriorityCmp[string])
+
+	// Pre-populate the queue with test items
+	testItems := []string{"task-1", "task-2", "task-3", "task-4", "task-5"}
+	for i, item := range testItems {
+		pq.Insert(item, i+1) // Initial priorities: 1, 2, 3, 4, 5
+	}
+
+	const numGoroutines = 10
+	const numUpdatesPerGoroutine = 20
+
+	ctx := context.Background()
+	g, _ := errgroup.WithContext(ctx)
+
+	// Launch goroutines that perform concurrent updates
+	for i := 0; i < numGoroutines; i++ {
+		goroutineID := i
+		g.Go(func() error {
+			for j := 0; j < numUpdatesPerGoroutine; j++ {
+				// Randomly update existing items
+				itemIndex := (goroutineID + j) % len(testItems)
+				item := testItems[itemIndex]
+				newPriority := goroutineID*100 + j
+
+				// Update may fail if item doesn't exist (due to concurrent pops), that's OK
+				_ = pq.Update(item, newPriority)
+			}
+			return nil
+		})
+	}
+
+	// Also run some concurrent inserts and pops to create realistic load
+	for i := 0; i < 3; i++ {
+		goroutineID := i
+		g.Go(func() error {
+			for j := 0; j < 10; j++ {
+				// Insert new items
+				newItem := fmt.Sprintf("new-task-%d-%d", goroutineID, j)
+				pq.Insert(newItem, j+50)
+
+				// Try to pop (might fail if queue is empty)
+				_, _ = pq.Pop()
+			}
+			return nil
+		})
+	}
+
+	// Wait for all operations to complete
+	err := g.Wait()
+	require.NoError(t, err, "All concurrent operations should complete without error")
+
+	// Verify the priority queue is still functional
+	pq.Insert("final-test", 1000)
+	task, err := pq.Pop()
+	require.NoError(t, err, "Priority queue should still be functional after concurrent updates")
+	require.NotNil(t, task, "Should be able to pop after concurrent operations")
+	assert.Equal(t, "final-test", task.Value, "Highest priority item should be popped first")
+	assert.Equal(t, 1000, task.Priority, "Priority should be preserved")
+}
+
+// TestPriorityQueue_MixedConcurrentOperations tests realistic concurrent usage patterns
+// combining Insert, Pop, and Update operations from multiple goroutines
+func TestPriorityQueue_MixedConcurrentOperations(t *testing.T) {
+	pq := NewPriorityQueue(PriorityCmp[string])
+
+	const numWorkers = 8
+	const numOperations = 100
+
+	ctx := context.Background()
+	g, _ := errgroup.WithContext(ctx)
+
+	// Start producer and consumer goroutines
+	startProducers(g, pq, numWorkers/2, numOperations)
+	startConsumers(g, pq, numWorkers/2, numOperations)
+
+	// Wait for all operations to complete
+	err := g.Wait()
+	require.NoError(t, err, "All mixed concurrent operations should complete without error")
+
+	// Verify final state functionality
+	verifyPriorityQueueFunctionality(t, pq)
+}
+
+// startProducers launches producer goroutines that insert and update tasks
+func startProducers(g *errgroup.Group, pq *PriorityQueue[string], numProducers, numOperations int) {
+	for i := 0; i < numProducers; i++ {
+		workerID := i
+		g.Go(func() error {
+			return runProducerWorker(pq, workerID, numOperations)
+		})
+	}
+}
+
+// runProducerWorker executes producer operations for a single worker
+func runProducerWorker(pq *PriorityQueue[string], workerID, numOperations int) error {
+	for j := 0; j < numOperations; j++ {
+		task := fmt.Sprintf("producer-%d-task-%d", workerID, j)
+		priority := workerID*1000 + j
+		pq.Insert(task, priority)
+
+		// Occasionally update an existing task's priority
+		if j%10 == 0 && j > 0 {
+			oldTask := fmt.Sprintf("producer-%d-task-%d", workerID, j-5)
+			newPriority := priority + 5000 // Higher priority
+			_ = pq.Update(oldTask, newPriority)
+		}
+	}
+	return nil
+}
+
+// startConsumers launches consumer goroutines that pop and process tasks
+func startConsumers(g *errgroup.Group, pq *PriorityQueue[string], numConsumers, numOperations int) {
+	for i := 0; i < numConsumers; i++ {
+		g.Go(func() error {
+			return runConsumerWorker(pq, numOperations)
+		})
+	}
+}
+
+// runConsumerWorker executes consumer operations for a single worker
+func runConsumerWorker(pq *PriorityQueue[string], numOperations int) error {
+	processedCount := 0
+	for processedCount < numOperations {
+		if task, err := pq.Pop(); err == nil {
+			// Simulate processing time variation
+			if processedCount%20 == 0 {
+				// Occasionally re-insert a task with different priority
+				newTask := fmt.Sprintf("reprocessed-%s", task.Value)
+				newPriority := task.Priority - 100 // Lower priority for reprocessing
+				pq.Insert(newTask, newPriority)
+			}
+			processedCount++
+		}
+		// If queue is empty, continue trying (producers might still be working)
+	}
+	return nil
+}
+
+// verifyPriorityQueueFunctionality tests that the priority queue maintains correct behavior
+func verifyPriorityQueueFunctionality(t *testing.T, pq *PriorityQueue[string]) {
+	// Insert some test items with known priorities
+	testPriorities := []int{100, 500, 50, 750, 25}
+	for i, priority := range testPriorities {
+		pq.Insert(fmt.Sprintf("final-test-%d", i), priority)
+	}
+
+	// Pop items and verify they come out in priority order (highest first)
+	poppedPriorities := collectTestPriorities(pq, len(testPriorities))
+
+	// Verify priorities are in descending order (max-heap behavior)
+	require.Equal(t, len(testPriorities), len(poppedPriorities), "Should pop all test items")
+	verifyDescendingOrder(t, poppedPriorities)
+}
+
+// collectTestPriorities pops test items and returns their priorities
+func collectTestPriorities(pq *PriorityQueue[string], expectedCount int) []int {
+	var poppedPriorities []int
+	for len(poppedPriorities) < expectedCount {
+		if task, popErr := pq.Pop(); popErr == nil {
+			if len(task.Value) >= 10 && task.Value[:10] == "final-test" { // Only check our test items
+				poppedPriorities = append(poppedPriorities, task.Priority)
+			}
+		} else {
+			break // No more items
+		}
+	}
+	return poppedPriorities
+}
+
+// verifyDescendingOrder checks that priorities are in descending order
+func verifyDescendingOrder(t *testing.T, priorities []int) {
+	for i := 1; i < len(priorities); i++ {
+		assert.GreaterOrEqual(t, priorities[i-1], priorities[i],
+			"Priorities should be in descending order (index %d: %d >= %d)",
+			i, priorities[i-1], priorities[i])
 	}
 }

--- a/workbench/go/pkg/priority_queue/priority_queue_test.go
+++ b/workbench/go/pkg/priority_queue/priority_queue_test.go
@@ -471,7 +471,7 @@ func TestPriorityQueue_TimeOrdering(t *testing.T) {
 
 			// Insert tasks manually to control timing
 			for _, task := range tt.setupTasks {
-				pq.heap.Insert(task)
+				require.NoError(t, pq.heap.Insert(task))
 			}
 
 			// Verify order
@@ -636,9 +636,9 @@ func TestPriorityQueue_DebugHeapBehavior(t *testing.T) {
 				task2 := Task[string]{Priority: 5, Value: "task2", Time: time.Now()}
 				task3 := Task[string]{Priority: 15, Value: "task3", Time: time.Now()}
 
-				heap.Insert(task1)
-				heap.Insert(task2)
-				heap.Insert(task3)
+				require.NoError(t, heap.Insert(task1))
+				require.NoError(t, heap.Insert(task2))
+				require.NoError(t, heap.Insert(task3))
 
 				t.Logf("Initial heap:")
 				for i, task := range heap.GetItems() {
@@ -652,7 +652,7 @@ func TestPriorityQueue_DebugHeapBehavior(t *testing.T) {
 					t.Logf("  [%d] %s priority %d", i, task.Value, task.Priority)
 				}
 
-				heap.UpHeap(1)
+				require.NoError(t, heap.UpHeap(1))
 				t.Logf("After UpHeap(1):")
 				for i, task := range heap.GetItems() {
 					t.Logf("  [%d] %s priority %d", i, task.Value, task.Priority)

--- a/workbench/go/pkg/sort/heap_sort.go
+++ b/workbench/go/pkg/sort/heap_sort.go
@@ -57,8 +57,11 @@ func fromPointerSlice[T any](ptrs []*T) []T {
 //	words := []string{"banana", "apple", "cherry"}
 //	sortedWords := sort.HeapSort(words)
 //	// sortedWords: ["apple", "banana", "cherry"]
-func HeapSort[T cmp.Ordered](arr []T) []T {
+func HeapSort[T cmp.Ordered](arr []T) ([]T, error) {
 	ptrs := toPointerSlice(arr)
-	ptrs = heap.HeapSort(ptrs)
-	return fromPointerSlice(ptrs)
+	ptrs, err := heap.HeapSort(ptrs)
+	if err != nil {
+		return nil, err
+	}
+	return fromPointerSlice(ptrs), nil
 }

--- a/workbench/go/pkg/sort/heap_sort_test.go
+++ b/workbench/go/pkg/sort/heap_sort_test.go
@@ -6,63 +6,73 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHeapSort_EmptySlice(t *testing.T) {
 	var empty []int
-	result := HeapSort(empty)
+	result, err := HeapSort(empty)
+	require.NoError(t, err)
 	assert.Empty(t, result, "HeapSort should handle empty slices")
 }
 
 func TestHeapSort_SingleElement(t *testing.T) {
 	single := []int{42}
-	result := HeapSort(single)
+	result, err := HeapSort(single)
+	require.NoError(t, err)
 	assert.Equal(t, []int{42}, result, "HeapSort should handle single element")
 }
 
 func TestHeapSort_AlreadySorted(t *testing.T) {
 	sorted := []int{1, 2, 3, 4, 5}
-	result := HeapSort(sorted)
+	result, err := HeapSort(sorted)
+	require.NoError(t, err)
 	assert.Equal(t, []int{1, 2, 3, 4, 5}, result, "HeapSort should handle already sorted arrays")
 }
 
 func TestHeapSort_ReverseSorted(t *testing.T) {
 	reverse := []int{5, 4, 3, 2, 1}
-	result := HeapSort(reverse)
+	result, err := HeapSort(reverse)
+	require.NoError(t, err)
 	assert.Equal(t, []int{1, 2, 3, 4, 5}, result, "HeapSort should handle reverse sorted arrays")
 }
 
 func TestHeapSort_WithDuplicates(t *testing.T) {
 	duplicates := []int{3, 1, 4, 1, 5, 9, 2, 6, 5}
-	result := HeapSort(duplicates)
+	result, err := HeapSort(duplicates)
+	require.NoError(t, err)
 	expected := []int{1, 1, 2, 3, 4, 5, 5, 6, 9}
 	assert.Equal(t, expected, result, "HeapSort should handle duplicates correctly")
 }
 
 func TestHeapSort_RandomOrder(t *testing.T) {
 	random := []int{64, 34, 25, 12, 22, 11, 90}
-	result := HeapSort(random)
+	result, err := HeapSort(random)
+	require.NoError(t, err)
 	expected := []int{11, 12, 22, 25, 34, 64, 90}
 	assert.Equal(t, expected, result, "HeapSort should sort random arrays correctly")
 }
 
 func TestHeapSort_Strings(t *testing.T) {
 	words := []string{"banana", "apple", "cherry", "date"}
-	result := HeapSort(words)
+	result, err := HeapSort(words)
+	require.NoError(t, err)
 	expected := []string{"apple", "banana", "cherry", "date"}
 	assert.Equal(t, expected, result, "HeapSort should work with strings")
 }
 
 func TestHeapSort_Float64(t *testing.T) {
 	floats := []float64{3.14, 2.71, 1.41, 0.57}
-	result := HeapSort(floats)
+	result, err := HeapSort(floats)
+	require.NoError(t, err)
 	expected := []float64{0.57, 1.41, 2.71, 3.14}
 	assert.Equal(t, expected, result, "HeapSort should work with float64")
 }
 
 func TestHeapSort_NegativeNumbers(t *testing.T) {
 	negatives := []int{-5, -1, -10, 0, 3, -3}
-	result := HeapSort(negatives)
+	result, err := HeapSort(negatives)
+	require.NoError(t, err)
 	expected := []int{-10, -5, -3, -1, 0, 3}
 	assert.Equal(t, expected, result, "HeapSort should handle negative numbers")
 }
@@ -75,7 +85,8 @@ func TestHeapSort_LargeDataset(t *testing.T) {
 		data[i] = rand.Intn(1000)
 	}
 
-	result := HeapSort(data)
+	result, err := HeapSort(data)
+	require.NoError(t, err)
 
 	// Verify it's sorted
 	assert.True(t, sort.IntsAreSorted(result), "Large dataset should be sorted")
@@ -87,7 +98,8 @@ func TestHeapSort_DoesNotModifyOriginal(t *testing.T) {
 	originalCopy := make([]int, len(original))
 	copy(originalCopy, original)
 
-	result := HeapSort(original)
+	result, err := HeapSort(original)
+	require.NoError(t, err)
 
 	// Original should be unchanged
 	assert.Equal(t, originalCopy, original, "HeapSort should not modify original slice")
@@ -99,7 +111,8 @@ func TestHeapSort_CustomOrderedType(t *testing.T) {
 	type Price float64
 
 	prices := []Price{19.99, 9.99, 29.99, 4.99}
-	result := HeapSort(prices)
+	result, err := HeapSort(prices)
+	require.NoError(t, err)
 	expected := []Price{4.99, 9.99, 19.99, 29.99}
 	assert.Equal(t, expected, result, "HeapSort should work with custom ordered types")
 }
@@ -119,7 +132,8 @@ func TestHeapSort_CorrectnessAgainstStandardLibrary(t *testing.T) {
 		sort.Ints(expected)
 
 		// Get our result
-		result := HeapSort(data)
+		result, err := HeapSort(data)
+		require.NoError(t, err)
 
 		assert.Equal(t, expected, result, "HeapSort result should match standard library sort for dataset %d", i)
 	}
@@ -134,7 +148,7 @@ func BenchmarkHeapSort_Random100(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		HeapSort(data)
+		_, _ = HeapSort(data)
 	}
 }
 
@@ -146,7 +160,7 @@ func BenchmarkHeapSort_Random1000(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		HeapSort(data)
+		_, _ = HeapSort(data)
 	}
 }
 
@@ -158,7 +172,7 @@ func BenchmarkHeapSort_Random10000(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		HeapSort(data)
+		_, _ = HeapSort(data)
 	}
 }
 
@@ -170,7 +184,7 @@ func BenchmarkHeapSort_Sorted1000(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		HeapSort(data)
+		_, _ = HeapSort(data)
 	}
 }
 
@@ -182,6 +196,6 @@ func BenchmarkHeapSort_Reverse1000(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		HeapSort(data)
+		_, _ = HeapSort(data)
 	}
 }

--- a/workbench/go/pkg/sort/sort_test.go
+++ b/workbench/go/pkg/sort/sort_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test that both sorting algorithms produce the same results
@@ -30,7 +31,8 @@ func TestSortingAlgorithmsConsistency(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test both algorithms produce the same result
-			heapResult := HeapSort(tc.data)
+			heapResult, err := HeapSort(tc.data)
+			require.NoError(t, err)
 			quickResult := QuickSort(tc.data)
 
 			assert.Equal(t, heapResult, quickResult,
@@ -55,7 +57,8 @@ func TestSortingAlgorithmsConsistency(t *testing.T) {
 func TestSortingAlgorithmsWithStrings(t *testing.T) {
 	words := []string{"zebra", "apple", "banana", "cherry", "date", "elderberry"}
 
-	heapResult := HeapSort(words)
+	heapResult, err := HeapSort(words)
+	require.NoError(t, err)
 	quickResult := QuickSort(words)
 
 	expected := []string{"apple", "banana", "cherry", "date", "elderberry", "zebra"}
@@ -69,7 +72,8 @@ func TestSortingAlgorithmsWithStrings(t *testing.T) {
 func TestSortingAlgorithmsWithFloats(t *testing.T) {
 	floats := []float64{3.14159, 2.71828, 1.41421, 0.57721, 1.61803}
 
-	heapResult := HeapSort(floats)
+	heapResult, err := HeapSort(floats)
+	require.NoError(t, err)
 	quickResult := QuickSort(floats)
 
 	expected := []float64{0.57721, 1.41421, 1.61803, 2.71828, 3.14159}
@@ -85,7 +89,8 @@ func TestOriginalSliceNotModified(t *testing.T) {
 	originalCopy := make([]int, len(original))
 	copy(originalCopy, original)
 
-	heapResult := HeapSort(original)
+	heapResult, err := HeapSort(original)
+	require.NoError(t, err)
 	assert.Equal(t, originalCopy, original, "HeapSort should not modify original slice")
 
 	quickResult := QuickSort(original)
@@ -113,7 +118,8 @@ func TestPerformanceComparison(t *testing.T) {
 	heapData := make([]int, len(data))
 	copy(heapData, data)
 	start := time.Now()
-	heapResult := HeapSort(heapData)
+	heapResult, err := HeapSort(heapData)
+	require.NoError(t, err)
 	heapTime := time.Since(start)
 
 	// Test QuickSort
@@ -161,7 +167,8 @@ func TestHeapSortWorstCase(t *testing.T) {
 		data[i] = i
 	}
 
-	result := HeapSort(data)
+	result, err := HeapSort(data)
+	require.NoError(t, err)
 
 	assert.True(t, sort.IntsAreSorted(result), "HeapSort should handle any input efficiently")
 	assert.Equal(t, data, result, "Result should be the same as input (already sorted)")
@@ -174,7 +181,8 @@ func TestSortingWithLargeNumbers(t *testing.T) {
 		-1000000000, -999999999, 0, 1, -1,
 	}
 
-	heapResult := HeapSort(largeNumbers)
+	heapResult, err := HeapSort(largeNumbers)
+	require.NoError(t, err)
 	quickResult := QuickSort(largeNumbers)
 
 	expected := []int{
@@ -192,7 +200,8 @@ func TestCustomOrderedType(t *testing.T) {
 
 	temps := []Temperature{98.6, 32.0, 212.0, 100.0, 0.0, -40.0}
 
-	heapResult := HeapSort(temps)
+	heapResult, err := HeapSort(temps)
+	require.NoError(t, err)
 	quickResult := QuickSort(temps)
 
 	expected := []Temperature{-40.0, 0.0, 32.0, 98.6, 100.0, 212.0}
@@ -215,7 +224,8 @@ func TestStressTestMultipleDatasets(t *testing.T) {
 			data[j] = rand.Intn(1000) - 500 // -500 to 499
 		}
 
-		heapResult := HeapSort(data)
+		heapResult, err := HeapSort(data)
+		require.NoError(t, err)
 		quickResult := QuickSort(data)
 
 		// Both should produce the same sorted result


### PR DESCRIPTION
This pull request adds thread safety to the generic heap and linked list implementations in Go, ensuring both data structures can be safely used by multiple goroutines concurrently. The changes introduce mutex locking to all public methods, update documentation to reflect the new concurrency guarantees, and add comprehensive tests to verify thread safety under concurrent access.

**Thread safety for heap and linked list:**

* Added `sync.RWMutex` to the `Heap` and `LinkedList` structs, and updated all public methods to use appropriate locking (`RLock` for reads, `Lock` for writes). Internal helper methods are now clearly separated and called only when the lock is already held. (`workbench/go/pkg/heap/heap.go`, `workbench/go/pkg/linked_list/linked_list.go`) [[1]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R28-R38) [[2]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R57-R61) [[3]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R70-R81) [[4]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R95-R118) [[5]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R154-R156) [[6]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767L126-R173) [[7]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R186-R188) [[8]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R198-R200) [[9]](diffhunk://#diff-6c1f9c69d2d69c17ebf87b14149db6bf5466231b4b0b227cbc0a5ff38e205c1bL1-R6) [[10]](diffhunk://#diff-6c1f9c69d2d69c17ebf87b14149db6bf5466231b4b0b227cbc0a5ff38e205c1bL14-R56) [[11]](diffhunk://#diff-6c1f9c69d2d69c17ebf87b14149db6bf5466231b4b0b227cbc0a5ff38e205c1bL44-R93) [[12]](diffhunk://#diff-6c1f9c69d2d69c17ebf87b14149db6bf5466231b4b0b227cbc0a5ff38e205c1bL70-R145)

* Updated the documentation for both packages to explain the thread safety guarantees and provide usage examples for concurrent scenarios. (`workbench/go/pkg/heap/heap.go`, `workbench/go/pkg/linked_list/doc.go`) [[1]](diffhunk://#diff-1d832d556b7813a7eb430ace911a40d68ec9ac576edb418155df6d87cca78767R4-R17) [[2]](diffhunk://#diff-c3860f9f21ce7df41fc1e3e9d1d40c7a8f437b5e3b5a238c54b3be1364465f17R16-R28) [[3]](diffhunk://#diff-c3860f9f21ce7df41fc1e3e9d1d40c7a8f437b5e3b5a238c54b3be1364465f17R73-R98) [[4]](diffhunk://#diff-6c1f9c69d2d69c17ebf87b14149db6bf5466231b4b0b227cbc0a5ff38e205c1bL14-R56)

**Testing for concurrency:**

* Added new tests using `errgroup` to verify thread safety of `Heap` operations (`Insert`, `Pop`, `Peek`, `Size`, `GetItems`, `UpHeap`, `DownHeap`) under concurrent access, including mixed read/write and stress scenarios. (`workbench/go/pkg/heap/heap_test.go`) [[1]](diffhunk://#diff-ebccb5d29da0cd4d8c815d0eaf34fdb1cce707b2a48ce02e49d3fdd0d3463c6bR4-R9) [[2]](diffhunk://#diff-ebccb5d29da0cd4d8c815d0eaf34fdb1cce707b2a48ce02e49d3fdd0d3463c6bR534-R733)

* Added necessary imports for concurrency testing (`sync`, `errgroup`) in both heap and linked list test files. (`workbench/go/pkg/heap/heap_test.go`, `workbench/go/pkg/linked_list/linked_list_test.go`) [[1]](diffhunk://#diff-ebccb5d29da0cd4d8c815d0eaf34fdb1cce707b2a48ce02e49d3fdd0d3463c6bR4-R9) [[2]](diffhunk://#diff-fe343d9caf1f7f889bef675e905b2a2a5db432c5c73f3903ea3e8d0100c82b36R4-R9)

**Minor related fix:**

* Updated a usage in the hash table to call the new thread-safe `Head()` method instead of directly accessing the field. (`workbench/go/pkg/hash_table/hash_table.go`)